### PR TITLE
Implementing autoscroll to current day - Calum

### DIFF
--- a/src/containers/Main/Main.css
+++ b/src/containers/Main/Main.css
@@ -7,23 +7,23 @@
 .promotion-window-button-current-date {
   height: 14vw;
   width: 14vw;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #ffffff;
   border-radius: 0;
   padding: 0;
 }
 
 .promotion-window-button {
-  background-color: #3278A7;
+  background-color: #3278a7;
 }
 
 .promotion-window-button-current-date {
-  background-color: #153D68;
+  background-color: #153d68;
 }
 
 .promotion-window-button:hover,
 .promotion-window-button-current-date:hover {
-  background-color: #153D68;
-  border-color: #153D68;
+  background-color: #153d68;
+  border-color: #153d68;
 }
 
 @media screen and (max-width: 1444px) {
@@ -44,5 +44,9 @@
   .promotion-window-button {
     height: 90vw !important;
     width: 90vw !important;
+  }
+
+  .promotion-window-button-current-date {
+    scroll-margin-top: 110px; /* to compensate for header - change to taste - Calum */
   }
 }

--- a/src/containers/Main/Main.jsx
+++ b/src/containers/Main/Main.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import "./Main.css";
 import moment from "moment";
 import Container from "react-bootstrap/Container";
@@ -8,7 +8,10 @@ import PromotionWindow from "../../components/PromotionWindow/PromotionWindow";
 import PromotionModal from "../../components/PromotionModal/PromotionModal";
 import config from "../../config.json";
 
+
 function Main() {
+  window.history.scrollRestoration = "manual";      //I added this to stop browser recalling last scroll location - Calum.
+ 
   const allDays = config.days;
 
   // For Production
@@ -27,8 +30,11 @@ function Main() {
 
   const promotionWindows = allDays.map((promotionWindow, index) => {
     return (
+      <>
+
       <Button
         key={index}
+        id={promotionWindow.Date}
         onClick={handleShow}
         className={(promotionWindow.Date !== currentDate) ? "promotion-window-button" : "promotion-window-button-current-date"}
       >
@@ -37,14 +43,23 @@ function Main() {
           promotionWindowDate={moment(promotionWindow.Date)}
         />
       </Button>
+      </>
     );
   });
 
+  useEffect(() => {        
+    if (window.matchMedia('(max-width: 600px)').matches) {                     //If mobile/vertical view is in effect                
+    document.getElementById(currentDate).scrollIntoView();                     //Scrolls to the current day.
+    }
+  })
+
   return (
-    <Container fluid className="main-container">
+    <>
+      <Container fluid className="main-container">
       <Row className="promotion-window-container">{promotionWindows}</Row>
       <PromotionModal show={show} handleClose={handleClose} />
     </Container>
+    </>
   );
 }
 


### PR DESCRIPTION
This kicks in at a width of 599px or less. Tested on Chrome desktop & Chrome on Android, seems to work on both.

I used the [scrollIntoView API](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) for this, which seems to be supported everywhere (in its simplest implementation).

Otherwise there's a line to override the browser's default scroll behaviour.

There's also a line in the CSS that bumps the view down a little bit to compensate for the header. This can be adjusted to taste.